### PR TITLE
Add a snapcraft build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Snap Status](https://build.snapcraft.io/badge/jhenstridge/python-snap-pkg.svg)](https://build.snapcraft.io/user/jhenstridge/python-snap-pkg)
+
 This repository contains snap packaging for the Python language
 interpreter and standard library.
 


### PR DESCRIPTION
Congrats on the Python snap. Here's a badge to show the current snap build status.